### PR TITLE
docs(readme): add GitHub stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@
 #### Tools
 
 [![Backend](https://skillicons.dev/icons?i=git,github,vscode,idea,windows,linux)](https://skillicons.dev)
+
+##
+
+<p align="center">
+    <a href="https://github.com/bielwdev"><img heigth="180em" src="https://github-readme-stats.vercel.app/api?username=bielwdev&show_icons=true&theme=transparent&include_all_commits=true"/></a>
+    <a href="https://github.com/bielwdev"><img height="195em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=bielwdev&layout=compact&langs_count=7&theme=transparent"/></a>
+</p>


### PR DESCRIPTION
This pull request adds GitHub statistics and to the README file. The following changes were made:

Added GitHub stats image showing the user’s GitHub contributions and activity.
Added a top languages image displaying the most used programming languages.
Integrated the images into the README to provide a better overview of the profile’s activity and skills.
The images are aligned at the center of the README page, providing a visual representation of the GitHub statistics and languages used.

